### PR TITLE
Configure production email delivery with Mailjet SMTP

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "noreply@#{ENV.fetch('FLY_APP_NAME', 'seedling-scheduler')}.fly.dev"
   layout "mailer"
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,20 @@
-<p>Welcome <%= @email %>!</p>
+<h2>Welcome to Seedling Scheduler, <%= @email %>!</h2>
 
-<p>You can confirm your account email through the link below:</p>
+<p>Thank you for signing up! To get started managing your garden tasks, please confirm your email address.</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p style="margin: 30px 0;">
+  <%= link_to 'Confirm My Email Address',
+      confirmation_url(@resource, confirmation_token: @token),
+      style: 'background-color: #4CAF50; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block;' %>
+</p>
+
+<p style="color: #666; font-size: 14px;">
+  Or copy and paste this link into your browser:<br>
+  <%= confirmation_url(@resource, confirmation_token: @token) %>
+</p>
+
+<hr style="margin: 30px 0; border: none; border-top: 1px solid #eee;">
+
+<p style="color: #999; font-size: 12px;">
+  If you didn't create an account with Seedling Scheduler, please ignore this email.
+</p>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,12 +2,31 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
-      /* Email styles need to be inline */
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+        color: #333;
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      h2 {
+        color: #2c5f2d;
+      }
+      a {
+        color: #4CAF50;
+      }
     </style>
   </head>
 
   <body>
     <%= yield %>
+
+    <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; color: #999; font-size: 12px;">
+      <p>Seedling Scheduler - Your Garden Task Manager</p>
+    </footer>
   </body>
 </html>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,15 +53,19 @@ Rails.application.configure do
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Enable delivery error reporting for debugging email issues in production
+  config.action_mailer.raise_delivery_errors = true
+
+  # Configure email delivery method
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
 
   # Set host to be used by links generated in mailer templates.
   # For Fly.io: Uses FLY_APP_NAME environment variable
   # For custom domain: Update to your actual domain (e.g., "yourdomain.com")
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("FLY_APP_NAME", "seedling-scheduler") + ".fly.dev"
+    host: ENV.fetch("FLY_APP_NAME", "seedling-scheduler") + ".fly.dev",
+    protocol: "https"
   }
 
   # Specify outgoing SMTP server. Add smtp/* credentials via: bin/rails credentials:edit
@@ -72,7 +76,8 @@ Rails.application.configure do
     address: Rails.application.credentials.dig(:smtp, :address),
     port: Rails.application.credentials.dig(:smtp, :port),
     authentication: :plain,
-    enable_starttls_auto: true
+    enable_starttls_auto: true,
+    domain: ENV.fetch("FLY_APP_NAME", "seedling-scheduler") + ".fly.dev"
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
- Enable SMTP delivery method and error reporting in production
- Set delivery_method to :smtp (was defaulting to :sendmail)
- Add HTTPS protocol to default_url_options for secure email links
- Add domain parameter to smtp_settings for HELO/EHLO
- Update ApplicationMailer sender to use FLY_APP_NAME
- Enhance confirmation email with professional styling and CTA button
- Improve mailer layout with responsive design and footer

This enables email verification for new user signups using the existing Mailjet credentials already configured in Rails credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)