### PR TITLE
Fix email deliverability by aligning sender addresses

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "noreply@#{ENV.fetch('FLY_APP_NAME', 'seedling-scheduler')}.fly.dev"
+  default from: "noreply@seedlingscheduler.com"
   layout "mailer"
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,9 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  # For fly.io deployment, using noreply@[appname].fly.dev
-  # Update to custom domain when available (e.g., "noreply@yourdomain.com")
-  config.mailer_sender = "noreply@#{ENV.fetch('FLY_APP_NAME', 'seedling-scheduler')}.fly.dev"
+  config.mailer_sender = "noreply@seedlingscheduler.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Update email FROM addresses to use seedlingscheduler.com instead of fly.dev domain. This fixes SPF/DKIM authentication failures that were causing emails to be delivered to spam folders.

Changes:
- ApplicationMailer: Changed default from address to noreply@seedlingscheduler.com
- Devise config: Changed mailer_sender to noreply@seedlingscheduler.com

This ensures consistency with production SMTP settings and enables proper email authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)