### PR TITLE
Remove filter for earlier tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,4 +77,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  # Pin Minitest to 5.x for Rails 8.1 compatibility
+  gem "minitest", "~> 5.25"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.19.0)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,8 +185,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.1)
-      prism (~> 1.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.12)
@@ -428,6 +427,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener
+  minitest (~> 5.25)
   propshaft
   puma (>= 5.0)
   rack-attack

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,8 +1,8 @@
 class PlantsController < ApplicationController
-  before_action :set_plant, only: [ :show, :edit, :update, :destroy, :regenerate_tasks ]
+  before_action :set_plant, only: [ :show, :edit, :update, :destroy, :regenerate_tasks, :mute, :unmute ]
 
   def index
-    @plants = current_user.plants.order(:name)
+    @plants = current_user.plants.order(Arel.sql("CASE WHEN muted_at IS NULL THEN 0 ELSE 1 END"), :name)
   end
 
   def show
@@ -44,6 +44,16 @@ class PlantsController < ApplicationController
   def regenerate_tasks
     @plant.generate_tasks!(Setting.frost_date)
     redirect_to @plant, notice: "Tasks regenerated based on current settings."
+  end
+
+  def mute
+    @plant.mute!
+    redirect_to plants_path, notice: "#{@plant.name} has been muted. Its tasks are now hidden."
+  end
+
+  def unmute
+    @plant.unmute!
+    redirect_to plants_path, notice: "#{@plant.name} has been unmuted. Its tasks are now visible."
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,22 +2,23 @@ class TasksController < ApplicationController
   before_action :set_task, only: [ :update, :complete, :skip, :reset, :destroy ]
 
   def index
-    @tasks = current_user.tasks
+    base_query = current_user.tasks
       .includes(:plant)
       .left_joins(:plant)
       .where("plants.muted_at IS NULL OR tasks.plant_id IS NULL")
-      .where("due_date >= ?", Date.current - Task::HISTORY_DAYS.days)
       .order(:due_date)
 
     respond_to do |format|
-      format.html
+      format.html do
+        @tasks = base_query
+      end
       format.json do
-        tasks = @tasks
-
-        if params[:start] && params[:end]
+        tasks = if params[:start] && params[:end]
           start_date = Date.parse(params[:start])
           end_date = Date.parse(params[:end])
-          tasks = tasks.where(due_date: start_date..end_date)
+          base_query.where(due_date: start_date..end_date)
+        else
+          base_query.where("due_date >= ?", Date.current - Task::HISTORY_DAYS.days)
         end
 
         render json: tasks.map { |t| task_to_json(t) }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,8 @@ class TasksController < ApplicationController
   def index
     @tasks = current_user.tasks
       .includes(:plant)
+      .left_joins(:plant)
+      .where("plants.muted_at IS NULL OR tasks.plant_id IS NULL")
       .where("due_date >= ?", Date.current - Task::HISTORY_DAYS.days)
       .order(:due_date)
 

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -12,6 +12,10 @@ class Plant < ApplicationRecord
     fridge_stratify: "fridge_stratify"  # Hidden from UI, placeholder for future
   }, prefix: true
 
+  # Scopes for muted/active filtering
+  scope :active, -> { where(muted_at: nil) }
+  scope :muted, -> { where.not(muted_at: nil) }
+
   # Validations
   validates :name, presence: true
   validates :sowing_method, presence: true
@@ -83,6 +87,18 @@ class Plant < ApplicationRecord
         status: :pending
       )
     end
+  end
+
+  def muted?
+    muted_at.present?
+  end
+
+  def mute!
+    update!(muted_at: Time.current)
+  end
+
+  def unmute!
+    update!(muted_at: nil)
   end
 
   private

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -18,9 +18,12 @@
       </thead>
       <tbody>
         <% @plants.each do |plant| %>
-          <tr>
+          <tr style="<%= 'background-color: #dee2e6;' if plant.muted? %>">
             <td>
               <%= link_to plant.name, plant_path(plant), class: "text-decoration-none fw-bold" %>
+              <% if plant.muted? %>
+                <span class="badge bg-secondary ms-2">Muted</span>
+              <% end %>
             </td>
             <td><%= plant.variety %></td>
             <td>
@@ -30,6 +33,17 @@
               <div class="d-flex flex-column flex-md-row gap-2 plant-actions-mobile" role="group">
                 <%= link_to "View", plant_path(plant), class: "btn btn-sm btn-outline-primary" %>
                 <%= link_to "Edit", edit_plant_path(plant), class: "btn btn-sm btn-outline-secondary" %>
+                <% if plant.muted? %>
+                  <%= button_to "Unmute", unmute_plant_path(plant),
+                        method: :patch,
+                        class: "btn btn-sm btn-outline-success" %>
+                <% else %>
+                  <%= button_to "Mute", mute_plant_path(plant),
+                        method: :patch,
+                        class: "btn btn-sm",
+                        style: "border-color: #b38600; color: #b38600;",
+                        data: { turbo_confirm: "Mute #{plant.name}? Its tasks will be hidden from the calendar and task list." } %>
+                <% end %>
                 <%= link_to "Delete", plant_path(plant),
                       class: "btn btn-sm btn-outline-danger",
                       data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>

--- a/app/views/plants/show.html.erb
+++ b/app/views/plants/show.html.erb
@@ -3,7 +3,12 @@
     <%# Plant Details Card %>
     <div class="card mb-4">
       <div class="card-header bg-primary text-white">
-        <h1 class="card-title mb-0 h3"><%= @plant.name %></h1>
+        <h1 class="card-title mb-0 h3">
+          <%= @plant.name %>
+          <% if @plant.muted? %>
+            <span class="badge bg-secondary ms-2 fs-6">Muted</span>
+          <% end %>
+        </h1>
       </div>
       <div class="card-body">
         <dl class="row mb-0">
@@ -144,9 +149,27 @@
       </div>
     <% end %>
 
+    <% if @plant.muted? %>
+      <div class="alert alert-warning mb-4" role="alert">
+        <strong>This plant is muted.</strong> Its tasks are hidden from the calendar and task list.
+        <%= button_to "Unmute", unmute_plant_path(@plant), method: :patch, class: "btn btn-sm btn-success ms-2" %>
+      </div>
+    <% end %>
+
     <%# Action Buttons %>
     <div class="d-flex flex-column flex-md-row gap-2 mb-4 plant-bottom-actions-mobile">
       <%= link_to "Edit Plant", edit_plant_path(@plant), class: "btn btn-primary" %>
+      <% if @plant.muted? %>
+        <%= button_to "Unmute Plant", unmute_plant_path(@plant),
+              method: :patch,
+              class: "btn btn-success" %>
+      <% else %>
+        <%= button_to "Mute Plant", mute_plant_path(@plant),
+              method: :patch,
+              class: "btn",
+              style: "background-color: #b38600; border-color: #b38600; color: white;",
+              data: { turbo_confirm: "Mute #{@plant.name}? Its tasks will be hidden from the calendar and task list." } %>
+      <% end %>
       <%= link_to "Delete Plant", plant_path(@plant),
             class: "btn btn-outline-danger",
             data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this plant and all its tasks?" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
   resources :plants do
     member do
       post :regenerate_tasks
+      patch :mute
+      patch :unmute
     end
   end
 

--- a/db/migrate/20260222012507_add_muted_at_to_plants.rb
+++ b/db/migrate/20260222012507_add_muted_at_to_plants.rb
@@ -1,0 +1,6 @@
+class AddMutedAtToPlants < ActiveRecord::Migration[8.1]
+  def change
+    add_column :plants, :muted_at, :datetime
+    add_index :plants, :muted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_06_211115) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_22_012507) do
   create_table "feedback_submissions", force: :cascade do |t|
     t.string "category", null: false
     t.datetime "created_at", null: false
@@ -41,6 +41,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_211115) do
     t.datetime "created_at", null: false
     t.string "days_to_sprout"
     t.integer "hardening_offset_days"
+    t.datetime "muted_at"
     t.string "name"
     t.text "notes"
     t.integer "plant_seedlings_offset_days"
@@ -51,6 +52,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_211115) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.string "variety"
+    t.index ["muted_at"], name: "index_plants_on_muted_at"
     t.index ["user_id"], name: "index_plants_on_user_id"
   end
 

--- a/test/controllers/plants_controller_test.rb
+++ b/test/controllers/plants_controller_test.rb
@@ -239,4 +239,41 @@ class PlantsControllerTest < ActionDispatch::IntegrationTest
     plant = Plant.last
     assert_equal 21, plant.plant_seeds_offset_days
   end
+
+  # ===================
+  # Mute/Unmute tests
+  # ===================
+
+  test "should mute plant" do
+    plant = plants(:zinnia)
+    assert_nil plant.muted_at
+
+    patch mute_plant_url(plant)
+
+    assert_redirected_to plants_url
+    plant.reload
+    assert_not_nil plant.muted_at
+  end
+
+  test "should unmute plant" do
+    plant = plants(:zinnia)
+    plant.mute!
+
+    patch unmute_plant_url(plant)
+
+    assert_redirected_to plants_url
+    plant.reload
+    assert_nil plant.muted_at
+  end
+
+  test "muted plant still visible in plants index" do
+    plant = plants(:zinnia)
+    plant.mute!
+
+    get plants_url
+
+    assert_response :success
+    assert_select "td", text: /Zinnia/
+    assert_select "span.badge", text: "Muted"
+  end
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -67,23 +67,24 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
   test "index orders tasks by due_date" do
     # Create tasks with specific dates to verify ordering
-    plant = plants(:zinnia)
-    plant.tasks.destroy_all
+    user = users(:one)
+    user.tasks.destroy_all
 
+    plant = plants(:zinnia)
     task1 = plant.tasks.create!(
-      user: users(:one),
+      user: user,
       task_type: "plant_seeds",
       due_date: Date.current + 5.days,
       status: "pending"
     )
     task2 = plant.tasks.create!(
-      user: users(:one),
+      user: user,
       task_type: "begin_hardening_off",
       due_date: Date.current + 2.days,
       status: "pending"
     )
     task3 = plant.tasks.create!(
-      user: users(:one),
+      user: user,
       task_type: "plant_seedlings",
       due_date: Date.current + 8.days,
       status: "pending"
@@ -92,10 +93,10 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     get tasks_url
     assert_response :success
 
-    # Verify tasks in the database are being queried with correct order
-    tasks = Task.where("due_date >= ?", Date.current - Task::HISTORY_DAYS.days).order(:due_date)
-    assert tasks.length >= 3, "Should have at least 3 tasks"
-    assert_equal task2.id, tasks[0].id, "First task should be the one due soonest"
+    # Verify tasks are ordered by due_date (soonest first)
+    tasks = user.tasks.order(:due_date)
+    assert_equal 3, tasks.length
+    assert_equal [task2.id, task1.id, task3.id], tasks.pluck(:id), "Tasks should be ordered by due_date"
   end
 
   test "index includes plant names for tasks" do
@@ -242,5 +243,57 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :unprocessable_entity
+  end
+
+  # ===================
+  # Muted plant filtering tests
+  # ===================
+
+  test "index excludes tasks from muted plants" do
+    plant = plants(:zinnia)
+    plant.mute!
+
+    get tasks_url
+
+    assert_response :success
+    assert_select "td", text: /Zinnia/, count: 0
+  end
+
+  test "index includes tasks from active plants" do
+    get tasks_url
+
+    assert_response :success
+    assert_select "td", text: /Zinnia/
+  end
+
+  test "index JSON excludes tasks from muted plants" do
+    plant = plants(:zinnia)
+    plant.mute!
+
+    get tasks_url(format: :json)
+
+    assert_response :success
+    json_response = JSON.parse(response.body)
+    plant_names = json_response.map { |t| t["plant_name"] }.compact
+    assert_not_includes plant_names, "Zinnia"
+  end
+
+  test "index still shows general tasks when plants are muted" do
+    # Create a general task (no plant)
+    general_task = Task.create!(
+      user: users(:one),
+      task_type: "garden_task",
+      due_date: Date.current,
+      status: "pending",
+      notes: "General garden work"
+    )
+
+    # Mute all plants
+    users(:one).plants.each(&:mute!)
+
+    get tasks_url
+
+    assert_response :success
+    assert_select "td", text: /General garden task/
   end
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -96,7 +96,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     # Verify tasks are ordered by due_date (soonest first)
     tasks = user.tasks.order(:due_date)
     assert_equal 3, tasks.length
-    assert_equal [task2.id, task1.id, task3.id], tasks.pluck(:id), "Tasks should be ordered by due_date"
+    assert_equal [ task2.id, task1.id, task3.id ], tasks.pluck(:id), "Tasks should be ordered by due_date"
   end
 
   test "index includes plant names for tasks" do

--- a/test/models/plant_test.rb
+++ b/test/models/plant_test.rb
@@ -213,4 +213,62 @@ class PlantTest < ActiveSupport::TestCase
   test "sowing_method enum values" do
     assert_equal %w[indoor_start direct_sow outdoor_start fridge_stratify], Plant.sowing_methods.keys
   end
+
+  # ===================
+  # Mute functionality tests
+  # ===================
+
+  test "muted? returns false for active plant" do
+    plant = plants(:zinnia)
+    assert_not plant.muted?
+  end
+
+  test "muted? returns true for muted plant" do
+    plant = plants(:zinnia)
+    plant.mute!
+    assert plant.muted?
+  end
+
+  test "mute! sets muted_at timestamp" do
+    plant = plants(:zinnia)
+    assert_nil plant.muted_at
+
+    plant.mute!
+
+    assert_not_nil plant.muted_at
+    assert plant.muted_at <= Time.current
+  end
+
+  test "unmute! clears muted_at timestamp" do
+    plant = plants(:zinnia)
+    plant.mute!
+    assert plant.muted?
+
+    plant.unmute!
+
+    assert_nil plant.muted_at
+    assert_not plant.muted?
+  end
+
+  test "active scope excludes muted plants" do
+    plant = plants(:zinnia)
+    user = users(:one)
+
+    assert_includes user.plants.active, plant
+
+    plant.mute!
+
+    assert_not_includes user.plants.active, plant
+  end
+
+  test "muted scope includes only muted plants" do
+    plant = plants(:zinnia)
+    user = users(:one)
+
+    assert_not_includes user.plants.muted, plant
+
+    plant.mute!
+
+    assert_includes user.plants.muted, plant
+  end
 end


### PR DESCRIPTION
  Root cause: The HISTORY_DAYS = 7 filter was applied to the shared @tasks query before splitting into HTML/JSON
  responses. This meant:
  - The task list only showed tasks from the past 7 days forward
  - The calendar's JSON endpoint inherited that same filter, so even when requesting January's date range, all January
  tasks were already excluded

  What changed (tasks_controller.rb):
  - The base query is now built without any date cutoff
  - HTML (task list): Uses base_query directly — all your tasks are shown, including January's
  - JSON (calendar): When start/end params are provided (which the calendar always sends), it filters to exactly that
  date range. When no range is given, it falls back to the HISTORY_DAYS filter