### PR TITLE
56 upgrade devise 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,10 +109,10 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     dotenv (3.2.0)

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div class="alert alert-danger alert-dismissible fade show" role="alert" data-turbo-cache="false">
+  <div class="alert alert-danger alert-dismissible fade show" role="alert" data-turbo-temporary>
     <h5 class="alert-heading">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,


### PR DESCRIPTION
Closes #56.

Clears the last two bundler-audit advisories (CVE-2026-32700 confirmable
race, CVE-2026-40295 timeoutable open redirect). `bundler-audit` now reports
no vulnerabilities — down from 139 when this round started.

No application changes were needed; the audit against Devise 5.0's breaking
changes is in the commit message. Notably no `config.secret_key` is set, so
existing confirmation and password-reset tokens stay valid in production.

Also included: a one-line rider swapping the Devise error alert to
`data-turbo-temporary`. `data-turbo-cache="false"` isn't recognised by Turbo 8,
so the alert was being cached into page snapshots and could reappear on back
navigation.

Verified: 302 unit tests, 24 system tests, rubocop, brakeman, bundler-audit.

To check by hand after deploy — not covered by tests: demo login/exit, and a
real signup + confirmation email.