### PR TITLE
Fix task modal leaking window listeners

### DIFF
--- a/app/frontend/controllers/task-modal_controller.js
+++ b/app/frontend/controllers/task-modal_controller.js
@@ -6,14 +6,20 @@ export default class extends Controller {
   connect() {
     this.modal = new window.bootstrap.Modal(document.getElementById('taskModal'))
 
+    // Hold on to the bound references: bind() returns a new function on every
+    // call, so binding again in disconnect() removes nothing and leaves this
+    // controller listening after its modal has been disposed.
+    this.boundCreateHandler = this.handleCreate.bind(this)
+    this.boundEditHandler = this.handleEdit.bind(this)
+
     // Listen for calendar events
-    window.addEventListener('calendar:create', this.handleCreate.bind(this))
-    window.addEventListener('calendar:edit', this.handleEdit.bind(this))
+    window.addEventListener('calendar:create', this.boundCreateHandler)
+    window.addEventListener('calendar:edit', this.boundEditHandler)
   }
 
   disconnect() {
-    window.removeEventListener('calendar:create', this.handleCreate.bind(this))
-    window.removeEventListener('calendar:edit', this.handleEdit.bind(this))
+    window.removeEventListener('calendar:create', this.boundCreateHandler)
+    window.removeEventListener('calendar:edit', this.boundEditHandler)
     if (this.modal) this.modal.dispose()
   }
 

--- a/test/system/calendar_test.rb
+++ b/test/system/calendar_test.rb
@@ -65,6 +65,31 @@ class CalendarTest < ApplicationSystemTestCase
     end
   end
 
+  test "task modal raises no errors after navigating away and back" do
+    visit calendar_tasks_path
+    sleep 2
+
+    # Turbo navigation rather than a full reload, so any listener the modal
+    # controller registered on window survives the round trip. If disconnect()
+    # fails to remove them, the orphaned listeners call show() on a modal that
+    # has already been disposed.
+    click_link "Table"
+    assert_selector ".task-tab-active", text: "Table", wait: 5
+    click_link "Calendar"
+    sleep 2
+
+    click_button "+ New Task"
+    assert_selector "#taskModal.show", wait: 5
+
+    # Assert on the console, not just on the modal: a stale listener throws
+    # without preventing the live one from opening the modal, so checking
+    # visibility alone cannot detect the leak.
+    errors = page.driver.browser.logs.get(:browser).select { |log| log.level == "SEVERE" }
+
+    assert_empty errors.map(&:message),
+      "Expected no JavaScript errors after re-entering the calendar page"
+  end
+
   test "view switcher changes calendar layout" do
     visit calendar_tasks_path
 


### PR DESCRIPTION
Fixes the console errors seen in production after opening the calendar:

    Uncaught TypeError: Cannot read properties of null (reading 'defaultPrevented')
        at handleCreate (task-modal_controller.js:25)
        at handleEdit   (task-modal_controller.js:48)

The controller added its window listeners with `this.handleCreate.bind(this)`
and tried to remove them by binding again. `bind()` returns a new function each
call, so `removeEventListener` never matched — while `disconnect()` still
disposed the modal. Each Turbo navigation through the calendar left another
orphaned listener holding a disposed modal, and the next `calendar:create` or
`calendar:edit` made all of them call `show()` on a null element.

Now keeps the bound references and removes those, matching what
`notification_controller` and `calendar_controller` already do.

**Not caused by the recent upgrades**, despite the timing. Neither this
controller, the calendar controller, nor the modal partial has changed since
the commit already running in production, and the vite_rails upgrade produced
identical asset hashes. The bug has been latent for months.

The regression test asserts on the **browser console**, not on modal
visibility. A stale listener throws without stopping the live one, so the modal
still opens and a visibility assertion passes while the bug is present — which
is why the existing calendar tests never caught this. Verified by reverting the
fix and watching the test fail with the same three errors.

The modal itself keeps working, so user impact is console noise plus a listener
leak that grows with each navigation. Worth deploying reasonably promptly, but
nothing is broken for users.